### PR TITLE
 feat(repository): implementa repositories para assunto, autor e livro

### DIFF
--- a/src/main/java/biblioteca/dev/luanluz/api/repository/AssuntoRepository.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/repository/AssuntoRepository.java
@@ -1,0 +1,11 @@
+package biblioteca.dev.luanluz.api.repository;
+
+import biblioteca.dev.luanluz.api.model.Assunto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AssuntoRepository extends JpaRepository<Assunto, Integer> {
+
+    boolean existsByDescricaoIgnoreCase(String descricao);
+}

--- a/src/main/java/biblioteca/dev/luanluz/api/repository/AutorRepository.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/repository/AutorRepository.java
@@ -1,0 +1,11 @@
+package biblioteca.dev.luanluz.api.repository;
+
+import biblioteca.dev.luanluz.api.model.Autor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AutorRepository extends JpaRepository<Autor, Integer> {
+
+    boolean existsByNomeIgnoreCase(String nome);
+}

--- a/src/main/java/biblioteca/dev/luanluz/api/repository/LivroRepository.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/repository/LivroRepository.java
@@ -1,0 +1,11 @@
+package biblioteca.dev.luanluz.api.repository;
+
+import biblioteca.dev.luanluz.api.model.Livro;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LivroRepository extends JpaRepository<Livro, Integer> {
+
+    boolean existsByTituloIgnoreCase(String titulo);
+}


### PR DESCRIPTION
- cria `assunto repository` para gerenciar operações de persistência da entidade `assunto`.
- Cria `autor repository` para gerenciar operações de persistência da entidade `autor`.
- cria `livro repository` para gerenciar operações de persistência da entidade `livro`.
- adiciona métodos `exists by ignore case` para verificar a existência de entidades por nome/descrição.

closes #3