### PR TITLE
fix(docker): adiciona variável de ambiente FRONTEND_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
         condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      FRONTEND_URL: ${FRONTEND_URL}
       POSTGRES_HOST: ${POSTGRES_HOST}
       POSTGRES_PORT: ${POSTGRES_PORT}
       POSTGRES_DB: ${POSTGRES_DB}


### PR DESCRIPTION
adiciona a variável de ambiente `FRONTEND_URL` ao `docker-compose.yml` para configurar o CORS na aplicação.

closes #37