### PR TITLE
fix(config): configura swagger e forward headers para deploy em proxy

### DIFF
--- a/src/main/java/biblioteca/dev/luanluz/api/ApiApplication.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/ApiApplication.java
@@ -1,8 +1,11 @@
 package biblioteca.dev.luanluz.api;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@OpenAPIDefinition(servers = {@Server(url = "${server.servlet.context-path}", description = "Default Server URL")})
 @SpringBootApplication
 public class ApiApplication {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.application.name=api
 
 # Configurações do servidor
 server.port=8080
+server.forward-headers-strategy=framework
 
 # Configuração de logging
 logging.level.org.springframework=INFO


### PR DESCRIPTION
- adiciona anotação `open api definition` para configurar a url do swagger com base no `server.servlet.context-path`.
- Adiciona `server.forward-headers-strategy=framework` para habilitar o uso de cabeçalhos encaminhados por proxies.

closes #39