### PR TITLE
fix: resolve problema de consulta n+1 para entidade livro

### DIFF
--- a/src/main/java/biblioteca/dev/luanluz/api/repository/LivroRepository.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/repository/LivroRepository.java
@@ -1,8 +1,14 @@
 package biblioteca.dev.luanluz.api.repository;
 
 import biblioteca.dev.luanluz.api.model.Livro;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface LivroRepository extends JpaRepository<Livro, Integer> {
@@ -10,4 +16,15 @@ public interface LivroRepository extends JpaRepository<Livro, Integer> {
     boolean existsByTituloIgnoreCase(String titulo);
 
     boolean existsByTituloIgnoreCaseAndCodigoNot(String titulo, Integer codigo);
+
+    @Query("SELECT l FROM Livro l " +
+            "LEFT JOIN FETCH l.autores " +
+            "LEFT JOIN FETCH l.assuntos " +
+            "WHERE l.codigo = :id")
+    Optional<Livro> findByIdWithRelations(@Param("id") Integer id);
+
+    @Query("SELECT DISTINCT l FROM Livro l " +
+            "LEFT JOIN FETCH l.autores " +
+            "LEFT JOIN FETCH l.assuntos")
+    Page<Livro> findAllWithRelations(Pageable pageable);
 }

--- a/src/main/java/biblioteca/dev/luanluz/api/service/AssuntoService.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/service/AssuntoService.java
@@ -11,12 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AssuntoService extends BaseService<Assunto, Integer, AssuntoRequestDTO, AssuntoResponseDTO> {
 
     private static final String RESOURCE_NAME = "Assunto";

--- a/src/main/java/biblioteca/dev/luanluz/api/service/AutorService.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/service/AutorService.java
@@ -11,12 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AutorService extends BaseService<Autor, Integer, AutorRequestDTO, AutorResponseDTO> {
 
     private static final String RESOURCE_NAME = "Autor";

--- a/src/main/java/biblioteca/dev/luanluz/api/service/BaseService.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/service/BaseService.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
-@Transactional(readOnly = true)
 public abstract class BaseService<T, ID, REQUEST_DTO, RESPONSE_DTO> {
 
     protected abstract JpaRepository<T, ID> getRepository();
@@ -23,8 +22,9 @@ public abstract class BaseService<T, ID, REQUEST_DTO, RESPONSE_DTO> {
 
     protected abstract void updateEntityFromDTO(REQUEST_DTO dto, T entity);
 
+    @Transactional
     public Page<RESPONSE_DTO> findAll(Pageable pageable) {
-        Page<T> page = getRepository().findAll(pageable);
+        Page<T> page = getAll(pageable);
 
         log.info("Encontrados {} {} na página {} de {}",
                 page.getNumberOfElements(),
@@ -35,6 +35,7 @@ public abstract class BaseService<T, ID, REQUEST_DTO, RESPONSE_DTO> {
         return page.map(this::toResponseDTO);
     }
 
+    @Transactional
     public RESPONSE_DTO findById(ID id) {
         T entity = findEntityById(id);
         log.info("{} encontrado: {}", getResourceName(), entity);
@@ -78,6 +79,10 @@ public abstract class BaseService<T, ID, REQUEST_DTO, RESPONSE_DTO> {
         getRepository().delete(entity);
 
         log.info("{} deletado com sucesso: {}", getResourceName(), entity);
+    }
+
+    protected Page<T> getAll(Pageable pageable) {
+        return getRepository().findAll(pageable);
     }
 
     protected T findEntityById(ID id) {

--- a/src/main/java/biblioteca/dev/luanluz/api/service/LivroService.java
+++ b/src/main/java/biblioteca/dev/luanluz/api/service/LivroService.java
@@ -4,6 +4,7 @@ import biblioteca.dev.luanluz.api.dto.request.LivroRequestDTO;
 import biblioteca.dev.luanluz.api.dto.response.LivroResponseDTO;
 import biblioteca.dev.luanluz.api.exception.DomainException;
 import biblioteca.dev.luanluz.api.exception.DuplicateResourceException;
+import biblioteca.dev.luanluz.api.exception.ResourceNotFoundException;
 import biblioteca.dev.luanluz.api.mapper.LivroMapper;
 import biblioteca.dev.luanluz.api.model.Assunto;
 import biblioteca.dev.luanluz.api.model.Autor;
@@ -13,9 +14,10 @@ import biblioteca.dev.luanluz.api.repository.AutorRepository;
 import biblioteca.dev.luanluz.api.repository.LivroRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -23,7 +25,6 @@ import java.util.Set;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class LivroService extends BaseService<Livro, Integer, LivroRequestDTO, LivroResponseDTO> {
 
     private static final String RESOURCE_NAME = "Livro";
@@ -58,6 +59,15 @@ public class LivroService extends BaseService<Livro, Integer, LivroRequestDTO, L
     @Override
     protected LivroResponseDTO toResponseDTO(Livro entity) {
         return livroMapper.toResponseDTO(entity);
+    }
+
+    protected Page<Livro> getAll(Pageable pageable) {
+        return livroRepository.findAllWithRelations(pageable);
+    }
+
+    protected Livro findEntityById(Integer id) {
+        return livroRepository.findByIdWithRelations(id)
+                .orElseThrow(() -> new ResourceNotFoundException(getResourceName(), getIdentifierFieldName(), id));
     }
 
     @Override

--- a/src/test/java/biblioteca/dev/luanluz/api/service/LivroServiceTest.java
+++ b/src/test/java/biblioteca/dev/luanluz/api/service/LivroServiceTest.java
@@ -100,7 +100,7 @@ class LivroServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<Livro> page = new PageImpl<>(Collections.singletonList(livro));
 
-        when(livroRepository.findAll(pageable)).thenReturn(page);
+        when(livroRepository.findAllWithRelations(pageable)).thenReturn(page);
         when(livroMapper.toResponseDTO(any(Livro.class))).thenReturn(responseDTO);
 
         // Act
@@ -109,13 +109,13 @@ class LivroServiceTest {
         // Assert
         assertNotNull(result);
         assertEquals(1, result.getContent().size());
-        verify(livroRepository, times(1)).findAll(pageable);
+        verify(livroRepository, times(1)).findAllWithRelations(pageable);
     }
 
     @Test
     void deveBuscarPorId() {
         // Arrange
-        when(livroRepository.findById(1)).thenReturn(Optional.of(livro));
+        when(livroRepository.findByIdWithRelations(1)).thenReturn(Optional.of(livro));
         when(livroMapper.toResponseDTO(livro)).thenReturn(responseDTO);
 
         // Act
@@ -125,17 +125,17 @@ class LivroServiceTest {
         assertNotNull(result);
         assertEquals(1, result.getCodigo());
         assertEquals("Fundação", result.getTitulo());
-        verify(livroRepository, times(1)).findById(1);
+        verify(livroRepository, times(1)).findByIdWithRelations(1);
     }
 
     @Test
     void deveLancarExcecaoQuandoNaoEncontrarPorId() {
         // Arrange
-        when(livroRepository.findById(999)).thenReturn(Optional.empty());
+        when(livroRepository.findByIdWithRelations(999)).thenReturn(Optional.empty());
 
         // Act & Assert
         assertThrows(ResourceNotFoundException.class, () -> livroService.findById(999));
-        verify(livroRepository, times(1)).findById(999);
+        verify(livroRepository, times(1)).findByIdWithRelations(999);
     }
 
     @Test
@@ -222,7 +222,7 @@ class LivroServiceTest {
     @Test
     void deveAtualizarLivro() {
         // Arrange
-        when(livroRepository.findById(1)).thenReturn(Optional.of(livro));
+        when(livroRepository.findByIdWithRelations(1)).thenReturn(Optional.of(livro));
         when(autorRepository.findById(1)).thenReturn(Optional.of(autor));
         when(assuntoRepository.findById(1)).thenReturn(Optional.of(assunto));
         when(livroRepository.existsByTituloIgnoreCaseAndCodigoNot(anyString(), anyInt())).thenReturn(false);
@@ -235,21 +235,21 @@ class LivroServiceTest {
 
         // Assert
         assertNotNull(result);
-        verify(livroRepository, times(1)).findById(1);
+        verify(livroRepository, times(1)).findByIdWithRelations(1);
         verify(livroRepository, times(1)).save(any(Livro.class));
     }
 
     @Test
     void deveDeletarLivro() {
         // Arrange
-        when(livroRepository.findById(1)).thenReturn(Optional.of(livro));
+        when(livroRepository.findByIdWithRelations(1)).thenReturn(Optional.of(livro));
         doNothing().when(livroRepository).delete(livro);
 
         // Act
         livroService.delete(1);
 
         // Assert
-        verify(livroRepository, times(1)).findById(1);
+        verify(livroRepository, times(1)).findByIdWithRelations(1);
         verify(livroRepository, times(1)).delete(livro);
     }
 


### PR DESCRIPTION
- implementa `find by id with relations` e `find all with relations` em `livro repository` para buscar antecipadamente `autores` e `assuntos` usando `left join fetch`.
- altera os serviços `base service` e `livro service` para utilizar esses novos métodos de repositório.
- remove anotações `transactional` a nível de classe em todos os serviços.

closes #50